### PR TITLE
Use nullable java main source set lookup

### DIFF
--- a/src/main/kotlin/JacocoToCoberturaPlugin.kt
+++ b/src/main/kotlin/JacocoToCoberturaPlugin.kt
@@ -53,7 +53,7 @@ class JacocoToCoberturaPlugin : Plugin<Project> {
                 kotlinSourcesSet
             }.getOrNull() ?: kotlinSourcesSet
             val javaSources = kotlin.runCatching { project.extensions.getByType(JavaPluginExtension::class.java).sourceSets }.getOrNull()
-                    ?.getByName(SourceSet.MAIN_SOURCE_SET_NAME)?.allSource?.files ?: emptySet()
+                    ?.findByName(SourceSet.MAIN_SOURCE_SET_NAME)?.allSource?.files ?: emptySet()
             val customSources = customSourcesConf
                     .filter { it.exists() }
                     .mapNotNull { it.listFiles()?.toList() }


### PR DESCRIPTION
For KMM projects the Java plugin may be applied but does not contain any SourceSets. In this case, `getByName()` throws an exception when SourceSets are not found. Instead we use `findByName()` to preserve the optionality of this lookup.

Without this change you'll likely see a build error saying `SourceSet with name 'main' not found.`