### PR TITLE
"Modernize" many aspects of the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,61 @@
 # JacocoToCobertura Gradle Plugin
 
-![Current release](https://img.shields.io/github/v/release/razvn/jacoco-to-cobertura-gradle-plugin)
-[![Gradle Plugin Portal](https://img.shields.io/badge/Gradle-v1.1.2-blue.svg)](https://plugins.gradle.org/plugin/net.razvan.jacoco-to-cobertura)
+[![Current release](https://img.shields.io/github/v/release/razvn/jacoco-to-cobertura-gradle-plugin)](../releases) [![Gradle Plugin Portal](https://img.shields.io/badge/Gradle-v1.1.2-blue.svg)](https://plugins.gradle.org/plugin/net.razvan.jacoco-to-cobertura)
 
-The aim of the plugin is to convert the Jacoco XML report to Cobertura report in order for GitLab to use the infos 
-for [showing the lines covered by tests in the Merge Request](https://docs.gitlab.com/ee/ci/testing/test_coverage_visualization.html).
+This plugin aims to convert the JaCoCo XML report to a Cobertura report for GitLab to use the data for [showing the lines covered by tests in the Merge Request](https://docs.gitlab.com/ee/ci/testing/test_coverage_visualization.html).
 
-The project is an adaptation of the python version [cover2cover](https://github.com/rix0rrr/cover2cover).
+This project adapts the python version [cover2cover](https://github.com/rix0rrr/cover2cover).
 
 ## How to use the plugin
 
 ### Add the plugin to your project
+
 ```kotlin
 plugins {
     jacoco
-    id("net.razvan.jacoco-to-cobertura") version "1.1.2"
+    id("net.razvan.jacoco-to-cobertura") version "<see latest version above>"
 }
 ```
 
-### Configure the plugin
+### Configure the task
 
-Options:
-- `inputFile` (required): location of Jacoco XML location
-- `outputFile`: location file the Cobertura report will be generated
-- `splitByPackage`: to generate multiple Cobertura reports split by packages
-- `verbose`: show some output information or not when the task runs
+| Property            | Description | Default Value |
+|---------------------|---|--|
+| `inputFile`         | JaCoCo XML file to read | XML report of single `JacocoReport` task found in the project; must be specified manually if zero or more than one `JacocoReport` task exists |
+| `outputFile`        | Cobertura XML file to generate | `cobertura-${inputFile.nameWithoutExtension}.xml` in the directory of `inputFile` |
+| `sourceDirectories` | Directories containing source files the JaCoCo report used | Source directories of single `JacocoReport` task found in the project; must be specified manually if zero or more than one `JacocoReport` tasks exist |
+| `splitByPackage`    | Whether to generate one Cobertura report per package | `false` |
 
-You must set at least the `inputFile` to the location where Jacoco XML report can be found.
+> **Note**
+> Due to the way the default values are set, projects that apply either the [JaCoCo plugin](https://docs.gradle.org/userguide/jacoco_plugin.html#jacoco_plugin) or the [JaCoCo Report Aggregation plugin](https://docs.gradle.org/userguide/jacoco_report_aggregation_plugin.html), work without requiring custom configuration of the `inputFile`, `outputFile` and `sourceDirectories` properties.
 
-If you set an `outoutFile` the Cobertura generated report will be generated there otherwise the default will be in the 
-same directory as the `inputFile` with a `cobertura-` prefix. 
-If the directory `outputFile`'s directory or parent directory does not exist, they wil be created (if possible).
-
-If you set `splitByPackage` property to `true` it will generate multiple reports files by package name.
-
-If `verbose` is set to true some output infos will be printed out (can be useful for debugging), otherwise no output.
-
+Should the default values not work for you, you can configure the task manually. For example:
 ```kotlin
-jacocoToCobertura {
-    inputFile.set(file("$buildDir/reports/xml/coverage.xml"))
-    outputFile.set(file("$buildDir/reports/xml/cobertura.xml"))
-}
-```
-(in this exemple if you don't set an `outputFile` the default one will be: `$buildDir/reports/xml/cobertura-coverage.xml`)
-
-Adding the property:
-```kotlin
-jacocoToCobertura {
+tasks.named<JacocoToCoberturaTask>(JacocoToCoberturaPlugin.TASK_NAME) {
+    inputFile.set(layout.buildDirectory.file("reports/xml/coverage.xml"))
+    outputFile.set(layout.buildDirectory.file("reports/xml/cobertura.xml"))
+    sourceDirectories.from(layout.projectDirectory.dir("src/main/java"))
     splitByPackage.set(true)
 }
 ```
-will generate multiple output files by the package name.
 
-Adding the property:
-```kotlin
-jacocoToCobertura {
-    verbose.set(true)
-}
-```
-will produce some output to the console (confirming the task run, its configuration, ...) otherwise no output will be generated.
+### Run the task
 
-### Run the plugin
-Run the task: `jacocoToCobertura`. The task should be run after `jacocoTestReport` in order to have the JacocoReport generated.
+Run the task `jacocoToCobertura`:
 ```shell
 ./gradlew jacocoToCobertura
 ```
 
-or just set it after `jacocoTestReport`
+To ensure the Cobertura report is generated whenever the JaCoCo task executes, the plugin task should be run after the `JacocoReport` task, e.g., `jacocoTestReport`. As the configuration table above shows, the default values should work in most cases. However, if your project works differently, you must manually ensure the report task runs before this plugin's conversion task. For example:
+
 ```kotlin
 tasks.jacocoTestReport {
     finalizedBy(tasks.jacocoToCobertura)
 }
 ```
-or `koverXmlReport`
+or
 ```kotlin
 tasks.koverXmlReport {
     finalizedBy(tasks.jacocoToCobertura)
 }
 ```
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("java-gradle-plugin")
-    kotlin("jvm") version "1.8.0"
+    kotlin("jvm") version "1.8.10"
     id("maven-publish")
     id("com.gradle.plugin-publish") version "1.1.0"
 }
@@ -15,9 +15,9 @@ repositories {
 
 dependencies {
     implementation("org.simpleframework:simple-xml:2.7.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10")
     testImplementation(kotlin("test"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.9.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
 }
 
 tasks.test {
@@ -31,20 +31,17 @@ tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "11"
 }
 
-pluginBundle {
-    website = "https://github.com/razvn/jacoco-to-cobertura-gradle-plugin"
-    vcsUrl = "https://github.com/razvn/jacoco-to-cobertura-gradle-plugin"
-    tags = listOf("jacoco", "cobertura", "report", "converter")
-}
-
 gradlePlugin {
+    website.set("https://github.com/razvn/jacoco-to-cobertura-gradle-plugin")
+    vcsUrl.set(website)
+
     plugins {
         create("JacocoToCoberturaPlugin") {
             id = "net.razvan.jacoco-to-cobertura"
             displayName = "Converts jacoco xml reports to cobertura"
             description = "This plugin converts jacoco xml reports to cobertura. Make sure the `jacocoTestReport` runs before."
+            tags.set(listOf("jacoco", "cobertura", "report", "converter"))
             implementationClass = "net.razvan.JacocoToCoberturaPlugin"
         }
     }
 }
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("java-gradle-plugin")
-    kotlin("jvm") version "1.8.10"
-    id("maven-publish")
+    `kotlin-dsl`
     id("com.gradle.plugin-publish") version "1.1.0"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
 }
-tasks.withType<KotlinCompile> {
+tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions.jvmTarget = "11"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionSha256Sum=1b6b558be93f29438d3df94b7dfee02e794b94d9aca4611a92cdb79b6b88e909
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,1 @@
-
 rootProject.name = "JacocoToCoberturaPlugin"
-

--- a/src/main/kotlin/JacocoToCoberturaPlugin.kt
+++ b/src/main/kotlin/JacocoToCoberturaPlugin.kt
@@ -35,7 +35,7 @@ class JacocoToCoberturaPlugin : Plugin<Project> {
             splitByPackage.convention(false)
         }
 
-        pluginManager.withPlugin(JacocoPlugin.PLUGIN_EXTENSION_NAME) {
+        plugins.withType<JacocoPlugin>().configureEach {
             tasks.withType<JacocoReport>().singleOrNull()?.let { jacocoTask ->
                 coberturaTask.configure {
                     /*

--- a/src/main/kotlin/JacocoToCoberturaPlugin.kt
+++ b/src/main/kotlin/JacocoToCoberturaPlugin.kt
@@ -1,156 +1,132 @@
 package net.razvan
 
-import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.SourceSet
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinJsProjectExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.internal.logging.ConsoleRenderer
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
+import org.gradle.language.base.plugins.LifecycleBasePlugin
+import org.gradle.testing.jacoco.plugins.JacocoPlugin
+import org.gradle.testing.jacoco.tasks.JacocoReport
 import org.simpleframework.xml.Serializer
 import org.simpleframework.xml.core.Persister
 import org.simpleframework.xml.stream.Format
 import java.io.File
 
 class JacocoToCoberturaPlugin : Plugin<Project> {
-    override fun apply(project: Project) {
-        project.task("jacocoToCobertura") { task ->
-            val extension = project.extensions.create("jacocoToCobertura", JacocoToCoberturaExtension::class.java)
-            task.doLast {
-                convert(project, extension)
-            }
-        }.apply {
-            group = "verification"
+    override fun apply(project: Project) = project.run {
+        val coberturaTask = tasks.register<JacocoToCoberturaTask>(TASK_NAME) {
+            outputFile.fileProvider(inputFile.map { inputFile ->
+                inputFile.asFile.parentFile.resolve("cobertura-${inputFile.asFile.nameWithoutExtension}.xml")
+            })
+
+            splitByPackage.convention(false)
         }
-    }
 
-    private fun convert(project: Project, extension: JacocoToCoberturaExtension) {
-        log(extension, "Conversion jacoco report to cobertura")
-        try {
-            val input = extension.inputFile.get().asFile
-                .also {
-                    if (!it.exists()) throw JacocoToCoberturaException(
-                        "File `${it.canonicalPath}` does not exists (current dir: `${
-                            File(
-                                "."
-                            ).canonicalPath
-                        })`"
-                    )
+        pluginManager.withPlugin(JacocoPlugin.PLUGIN_EXTENSION_NAME) {
+            tasks.withType<JacocoReport>().singleOrNull()?.let { jacocoTask ->
+                coberturaTask.configure {
+                    /*
+                    We'd like to use the following to set up the task dependency at the same time as
+                    we set up the value, but due to https://github.com/gradle/gradle/issues/6619 we
+                    get the following error instead:
+
+                    > Property 'outputLocation' is declared as an output property of Report xml (type
+                    TaskGeneratedSingleFileReport) but does not have a task associated with it.
+                    */
+                    // inputFile.convention(jacocoTask.reports.xml.outputLocation)
+
+                    dependsOn(jacocoTask)
+                    inputFile.convention(jacocoTask.reports.xml.outputLocation.locationOnly)
+
+                    sourceDirectories.from(jacocoTask.sourceDirectories)
                 }
-            val output = extension.outputFile.orNull?.asFile ?: defaultOutputFile(input)
-            makeDirsIfNeeded(output.parentFile)
-
-            val splitByPackage = extension.splitByPackage.getOrElse(false)
-
-            log(
-                extension,
-                "\tJacocoToCobertura: Calculated configuration: input: $input, output: $output, splitByPackage: $splitByPackage"
-            )
-            val customSourcesConf = emptySet<File>()
-
-            val jacocoData = loadJacocoData(input)
-
-            val kotlinSources: Set<File> = allKotlinSources(project)
-
-            val javaSources = runCatching { project.extensions.getByType(JavaPluginExtension::class.java).sourceSets }
-                .getOrNull()
-                ?.findByName(SourceSet.MAIN_SOURCE_SET_NAME)?.allSource?.files
-                ?.filter { it !in kotlinSources }
-                ?: emptySet()
-            val customSources = customSourcesConf
-                .filter { it.exists() }
-                .mapNotNull { it.listFiles()?.toList() }
-                .flatten()
-                .toSet()
-
-            log(extension, "Sources: - Kotlin: `${kotlinSources.size}`, Java: `${javaSources.size}`")
-            val allSources = kotlinSources + javaSources + customSources
-            val roots = sourcesRoots(allSources, jacocoData)
-
-            if (splitByPackage) {
-                jacocoData.packages.forEach { packageElement ->
-                    val packageName = packageElement.name?.replace('/', '.')
-                    val packageData = jacocoData.copy(packages = listOf(packageElement))
-                    val packageOut = File(output.absolutePath.replace(".xml", "-${packageName}.xml"))
-                    writeCoberturaData(packageOut, transformData(packageData, roots))
-                }
-            } else {
-                writeCoberturaData(output, transformData(jacocoData, roots))
-            }
-
-            log(extension, "Cobertura report generated in: `$output`")
-        } catch (e: Exception) {
-            println("Error while running JacocoToCobertura conversion: `${e.message} [configuration: input: `${extension.inputFile.get()}` | output: `${extension.outputFile.get()}`]")
-            if (e !is JacocoToCoberturaException) {
-                throw e
             }
         }
     }
 
-    private fun allKotlinSources(project: Project): Set<File> {
-        val multi = runCatching {
-            kotlinSourcesFiles(project.extensions.getByType(KotlinMultiplatformExtension::class.java).sourceSets)
-        }.getOrDefault(emptySet())
-        val android = runCatching {
-            kotlinSourcesFiles(project.extensions.getByType(KotlinAndroidProjectExtension::class.java).sourceSets)
-        }.getOrDefault(emptySet())
-        val jvm = runCatching {
-            kotlinSourcesFiles(project.extensions.getByType(KotlinJvmProjectExtension::class.java).sourceSets)
-        }.getOrDefault(emptySet())
-        val js = runCatching {
-            kotlinSourcesFiles(project.extensions.getByType(KotlinJsProjectExtension::class.java).sourceSets)
-        }.getOrDefault(emptySet())
+    companion object {
+        const val TASK_NAME = "jacocoToCobertura"
+    }
+}
 
-        return multi + android + jvm + js
+abstract class JacocoToCoberturaTask : DefaultTask() {
+    @get:InputFile
+    abstract val inputFile: RegularFileProperty
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @get:IgnoreEmptyDirectories
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:InputFiles
+    abstract val sourceDirectories: ConfigurableFileCollection
+
+    @get:Input
+    abstract val splitByPackage: Property<Boolean>
+
+    init {
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
     }
 
-    private fun kotlinSourcesFiles(sourceSets: NamedDomainObjectContainer<KotlinSourceSet>): Set<File> =
-        sourceSets
-            .filterNot { it.name.contains("test", true) }
-            .flatMap { sourcesSet ->
-                sourcesSet.kotlin.srcDirs.flatMap { file ->
-                    file.walkTopDown().mapNotNull {
-                        if (it.isFile) it else null
+    @TaskAction
+    private fun convert() {
+        val consoleRenderer = ConsoleRenderer()
+
+        logger.debug("Converting JaCoCo report to Cobertura")
+
+        val input = inputFile.asFile.get()
+            .also {
+                if (!it.exists()) throw JacocoToCoberturaException(
+                    "File `${it.absolutePath}` does not exist"
+                )
+            }
+        val output = outputFile.asFile.get()
+            .also {
+                if (!it.parentFile.exists()) {
+                    try {
+                        if (!it.parentFile.mkdirs()) throw JacocoToCoberturaException("`mkdirs()` returned false")
+                    } catch (e: Exception) {
+                        throw JacocoToCoberturaException("Output file directory `${it.parentFile.canonicalPath} does not exists and couldn't be created, error: `${e.message}`")
                     }
                 }
-            }.toSet()
-
-    @Throws(JacocoToCoberturaException::class)
-    private fun makeDirsIfNeeded(file: File?) {
-        if (file != null && !file.exists()) {
-            try {
-                if (!file.mkdirs()) throw JacocoToCoberturaException("`mkdirs()` returned false")
-            } catch (e: Exception) {
-                throw JacocoToCoberturaException("Output file directory `${file.canonicalPath} does not exists and couldn't be created, error: `${e.message}`")
             }
+
+        val sourceDirectories = sourceDirectories.files.map { it.absolutePath }
+        val splitByPackage = splitByPackage.getOrElse(false)
+
+        logger.debug(
+            "Calculated configuration: input: $input, output: $output, splitByPackage: $splitByPackage, sourceDirs: ${sourceDirectories.joinToString("\n", "\n")}"
+        )
+
+        val jacocoData = loadJacocoData(input)
+
+        if (splitByPackage) {
+            jacocoData.packages.forEach { packageElement ->
+                val packageName = packageElement.name?.replace('/', '.')
+                val packageData = jacocoData.copy(packages = listOf(packageElement))
+                val packageOut = File(output.absolutePath.replace(".xml", "-${packageName}.xml"))
+                writeCoberturaData(packageOut, transformData(packageData, sourceDirectories))
+                logger.lifecycle("Cobertura report for package $packageName generated at ${consoleRenderer.asClickableFileUrl(packageOut)}")
+            }
+        } else {
+            writeCoberturaData(output, transformData(jacocoData, sourceDirectories))
+            logger.info("Cobertura report generated at ${consoleRenderer.asClickableFileUrl(output)}")
         }
     }
 
-    @Throws(JacocoToCoberturaException::class)
-    private fun transformData(jacocoData: Jacoco.Report, sources: Collection<String>) = try {
-        Cobertura.Coverage(jacocoData, sources)
-    } catch (e: Exception) {
-        throw JacocoToCoberturaException("Transforming Jacoco Data to Cobertura error: `${e.message}`")
-    }
-
-    @Throws(JacocoToCoberturaException::class)
-    private fun writeCoberturaData(outputFile: File, data: Cobertura.Coverage) = with(outputFile) {
-        try {
-            Persister(Format("<?xml version=\"1.0\" encoding= \"UTF-8\" ?>")).write(data, this)
-        } catch (e: Exception) {
-            throw JacocoToCoberturaException("Writing Cobertura Data to file `${this.canonicalPath}` error: `${e.message}`")
-        }
-    }
-
-    @Throws(JacocoToCoberturaException::class)
     private fun loadJacocoData(fileIn: File): Jacoco.Report = try {
         val serializer: Serializer = Persister()
         serializer.read(Jacoco.Report::class.java, fileIn)
@@ -158,52 +134,19 @@ class JacocoToCoberturaPlugin : Plugin<Project> {
         throw JacocoToCoberturaException("Loading Jacoco report error: `${e.message}`")
     }
 
-    private fun defaultOutputFile(inputFile: File): File {
-        val inputPath = inputFile.canonicalPath
-        val position = inputPath.lastIndexOf("/") + 1
-        val outputPath = "${inputPath.substring(0, position)}cobertura-${inputPath.substring(position)}"
-        val outputFile = File(outputPath)
-        if (!outputFile.canWrite()) throw JacocoToCoberturaException("Can't write to the default location of: `$outputPath`")
-        return outputFile
+    private fun transformData(jacocoData: Jacoco.Report, sources: Collection<String>) = try {
+        Cobertura.Coverage(jacocoData, sources)
+    } catch (e: Exception) {
+        throw JacocoToCoberturaException("Transforming Jacoco Data to Cobertura error: `${e.message}`")
     }
 
-    private fun sourcesRoots(allSources: Set<File>, jacocoData: Jacoco.Report): Set<String> {
-        val jacocoPackages = jacocoData.packagesNames()
-        return allSources.map { it.canonicalPath }
-            .mapNotNull { sourceName ->
-                val p = jacocoPackages.firstOrNull { sourceName.contains(it) }
-                    ?: jacocoPackages.firstOrNull {
-                        sourceName.contains(
-                            it.replace(
-                                "/",
-                                "."
-                            )
-                        )
-                    } // in case the package is in dot format
-                p?.let {
-                    val sourcePath = sourceName.substringBefore(it)
-                    if (sourcePath != sourceName) sourcePath else sourceName.substringBefore(it.replace("/", "."))
-                }
-            }.toSet()
+    private fun writeCoberturaData(outputFile: File, data: Cobertura.Coverage) = with(outputFile) {
+        try {
+            Persister(Format("<?xml version=\"1.0\" encoding= \"UTF-8\" ?>")).write(data, this)
+        } catch (e: Exception) {
+            throw JacocoToCoberturaException("Writing Cobertura Data to file `${this.canonicalPath}` error: `${e.message}`")
+        }
     }
-
-    fun log(extension: JacocoToCoberturaExtension, msg: String) {
-        if (extension.verbose.getOrElse(false)) println(msg)
-    }
-}
-
-interface JacocoToCoberturaExtension {
-    @get:InputFile
-    val inputFile: RegularFileProperty
-
-    @get:OutputFile
-    val outputFile: RegularFileProperty
-
-    @get:Input
-    val splitByPackage: Property<Boolean>
-
-    @get:Input
-    val verbose: Property<Boolean>
 }
 
 private class JacocoToCoberturaException(msg: String) : Exception(msg)

--- a/src/main/kotlin/JacocoToCoberturaPlugin.kt
+++ b/src/main/kotlin/JacocoToCoberturaPlugin.kt
@@ -123,7 +123,7 @@ abstract class JacocoToCoberturaTask : DefaultTask() {
             }
         } else {
             writeCoberturaData(output, transformData(jacocoData, sourceDirectories))
-            logger.info("Cobertura report generated at ${consoleRenderer.asClickableFileUrl(output)}")
+            logger.lifecycle("Cobertura report generated at ${consoleRenderer.asClickableFileUrl(output)}")
         }
     }
 

--- a/src/test/kotlin/JacocoToCoberturaPluginTest.kt
+++ b/src/test/kotlin/JacocoToCoberturaPluginTest.kt
@@ -8,7 +8,7 @@ class JacocoToCoberturaPluginTest {
     @Test
     fun `task exists`() {
         val project = ProjectBuilder.builder().build()
-        project.pluginManager.apply(JacocoToCoberturaPlugin::class)
+        project.plugins.apply(JacocoToCoberturaPlugin::class)
 
         assertDoesNotThrow {
             project.tasks.getByName(JacocoToCoberturaPlugin.TASK_NAME)

--- a/src/test/kotlin/JacocoToCoberturaPluginTest.kt
+++ b/src/test/kotlin/JacocoToCoberturaPluginTest.kt
@@ -1,18 +1,17 @@
 import net.razvan.JacocoToCoberturaPlugin
+import org.gradle.kotlin.dsl.apply
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 
 class JacocoToCoberturaPluginTest {
-
     @Test
     fun `task exists`() {
         val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply(JacocoToCoberturaPlugin::class)
 
-        // project.pluginManager.apply(JacocoToCoberturaPlugin::class.java)
-        project.pluginManager.apply("net.razvan.jacoco-to-cobertura")
         assertDoesNotThrow {
-            project.tasks.getByName("jacocoToCobertura")
+            project.tasks.getByName(JacocoToCoberturaPlugin.TASK_NAME)
         }
     }
 }


### PR DESCRIPTION
* Update Gradle and all dependencies to the latest available versions.
* Use the `kotlin-dsl` plugin to use Kotlin-specific Gradle extension functions that simplify a few lines of code.
* Don't catch and swallow exceptions; let the user decide what to do instead.
* Use the task's logger for logging.
    * Only log a minimum by default and remove the `verbose` option in favor of giving more details in the `info` and `debug` log levels.
    * Make logged file paths clickable.
* Fix source directories lookup relying on known plugins being applied _on the same project_, breaking for scenarios where a root project aggregates JaCoCo reports.
* Remove the extension in favor of task properties and make the default task name accessible. This allows users to set up multiple tasks while also being able to configure the single default task that's automatically added when applying the plugin.
* Use known constants, e.g., for the task's group name.
* Support Gradle's configuration cache (due to the above changes to the task).
* Add support for the JaCoCo and JaCoCo Report Aggregation plugins by default without requiring additional configuration.
* Update the Readme for all changes.

Resolves #8.