### PR TITLE
Mark rootPackageToRemove as optional

### DIFF
--- a/src/main/kotlin/JacocoToCoberturaPlugin.kt
+++ b/src/main/kotlin/JacocoToCoberturaPlugin.kt
@@ -79,6 +79,7 @@ abstract class JacocoToCoberturaTask : DefaultTask() {
     @get:Input
     abstract val splitByPackage: Property<Boolean>
 
+    @get:Optional
     @get:Input
     abstract val rootPackageToRemove: Property<String>
 


### PR DESCRIPTION
Gradle 8.12 complains when trying to use the new v1.3.0:

```* What went wrong:
A problem was found with the configuration of task ':jacocoToCobertura' (type 'JacocoToCoberturaTask').
  - In plugin 'net.razvan.jacoco-to-cobertura' type 'net.razvan.JacocoToCoberturaTask' property 'rootPackageToRemove' doesn't have a configured value.

    Reason: This property isn't marked as optional and no value has been configured.

    Possible solutions:
      1. Assign a value to 'rootPackageToRemove'.
      2. Mark property 'rootPackageToRemove' as optional.

    For more information, please refer to https://docs.gradle.org/8.12/userguide/validation_problems.html#value_not_set in the Gradle documentation.```