### PR TITLE
Change inputFile as string so it can be optional and not fail if not set or file does not exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This list is not intended to be all-encompassing - it will document major and breaking changes with their rationale when appropriate:
 
+### v1.4.0
+- configuration change [Breaking]: inputFile is a path instead of a file object so the plugin won't fail if the file does not exist (see readme for details)
+- add a new configuration option `failOnInputNotFound` - if set to true the task will fail if the inputFile does not exist, otherwise the task  will exit with a la log message.  
+
 ### v1.3.0
 - Upgrade to gradle 8.12 & lib updates H/T @eliezio
 - Added new config option `rootPackageToRemove` to strip the root package from the filename name in the cobertura report. (useful for kotlin root classe that are not in a package directory)

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ plugins {
 
 ### Configure the task
 
-| Property               | Description                                                | Default Value |
-|------------------------|------------------------------------------------------------|--|
-| `inputFile`            | JaCoCo XML file to read                                    | XML report of single `JacocoReport` task found in the project; must be specified manually if zero or more than one `JacocoReport` task exists |
-| `outputFile`           | Cobertura XML file to generate                             | `cobertura-${inputFile.nameWithoutExtension}.xml` in the directory of `inputFile` |
+| Property               | Description                                                | Default Value                                                                                                                                         |
+|------------------------|------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `inputFile`            | JaCoCo XML file full path to read                          | XML report of single `JacocoReport` task found in the project; must be specified manually if zero or more than one `JacocoReport` task exists         |
+| `outputFile`           | Cobertura XML file to generate                             | `cobertura-${inputFile.nameWithoutExtension}.xml` in the directory of `inputFile`                                                                     |
 | `sourceDirectories`    | Directories containing source files the JaCoCo report used | Source directories of single `JacocoReport` task found in the project; must be specified manually if zero or more than one `JacocoReport` tasks exist |
-| `splitByPackage`       | Whether to generate one Cobertura report per package       | `false` |
-| `rootPackageToRemove`  | Root package to remove from the begging of filenames       | `` |
+| `splitByPackage`       | Whether to generate one Cobertura report per package       | `false`                                                                                                                                               |
+| `rootPackageToRemove`  | Root package to remove from the begging of filenames       | ``                                                                                                                                                    |
+| `failOnInputNotFound`  | Weather to fail if inputFile not found or just do nothing  | `false`                                                                                                                                               |
 
 > **Note**
 > Due to the way the default values are set, projects that apply either the [JaCoCo plugin](https://docs.gradle.org/userguide/jacoco_plugin.html#jacoco_plugin) or the [JaCoCo Report Aggregation plugin](https://docs.gradle.org/userguide/jacoco_report_aggregation_plugin.html), work without requiring custom configuration of the `inputFile`, `outputFile` and `sourceDirectories` properties.
@@ -33,13 +34,17 @@ plugins {
 Should the default values not work for you, you can configure the task manually. For example:
 ```kotlin
 tasks.named<JacocoToCoberturaTask>(JacocoToCoberturaPlugin.TASK_NAME) {
-    inputFile.set(layout.buildDirectory.file("reports/xml/coverage.xml"))
+    inputFile.set(layout.buildDirectory.file("reports/xml/coverage.xml").get().asFile.absolutePath)
     outputFile.set(layout.buildDirectory.file("reports/xml/cobertura.xml"))
     sourceDirectories.from(layout.projectDirectory.dir("src/main/java"))
     splitByPackage.set(true)
+    failOnInputNotFound.set(true)
     rootPackageToRemove.set("com.example")
 }
 ```
+> **Note**
+> Due to this gradle issue https://github.com/gradle/gradle/issues/2016 there's no way have the inputFile as optional file.
+> The `@InputFile` annotation requires the file to exists otherwise it fails. Because of that, I changed the inputFile as string path to the file to covert.
 
 ### Run the task
 
@@ -47,7 +52,10 @@ Run the task `jacocoToCobertura`:
 ```shell
 ./gradlew jacocoToCobertura
 ```
-
+If you don't want livecycle logs for the task, you can run it with the `--quiet` or `--warn` flag:
+```shell
+./gradlew -w jacocoToCobertura
+```
 To ensure the Cobertura report is generated whenever the JaCoCo task executes, the plugin task should be run after the `JacocoReport` task, e.g., `jacocoTestReport`. As the configuration table above shows, the default values should work in most cases. However, if your project works differently, you must manually ensure the report task runs before this plugin's conversion task. For example:
 
 ```kotlin

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 kotlin.code.style=official
-version=1.3.0
+version=1.4.0


### PR DESCRIPTION
The `inputFile` property will be a string as a path to the report file. This way if the value is not set or the file does not exist the task does not fail and fail the build.

Gradle `@InputFile`  property does not work as `@Optional` (see this gradle issue https://github.com/gradle/gradle/issues/2016), so unfortunaly it will bring a breaking change in the configuration of the plugin.

A new option is added `failOnInputNotFound` as boolean. If set to `true` the task will fail if the inputFile does not exist.

Fixes #20, #26 
